### PR TITLE
DATA-1393: seqsender debugging misc

### DIFF
--- a/submission_preparation.py
+++ b/submission_preparation.py
@@ -118,6 +118,8 @@ def generate_XML(unique_name, main_df, generate_biosample, generate_sra):
                 datatype.text = "generic-data"
                 if config_dict["ncbi"]["SRA_file_column2"] != "" and pd.isnull(row[config_dict["ncbi"]["SRA_file_column2"]]) == False:
                     print("WHY AM I HERE?")
+                    print("config_dict[\"ncbi\"][\"SRA_file_column2\"]: ", config_dict["ncbi"]["SRA_file_column2"])
+                    print("row[config_dict[\"ncbi\"][\"SRA_file_column2\"]]: ", row[config_dict["ncbi"]["SRA_file_column2"]])
                     sys.exit(1)
                     file = ET.SubElement(addfile, "File")
                     file.set("cloud_url", row[config_dict["ncbi"]["SRA_file_column2"]])

--- a/submission_preparation.py
+++ b/submission_preparation.py
@@ -116,16 +116,14 @@ def generate_XML(unique_name, main_df, generate_biosample, generate_sra):
                 file.set("cloud_url", row[config_dict["ncbi"]["SRA_file_column1"]])
                 datatype=ET.SubElement(file, "DataType")
                 datatype.text = "generic-data"
-                if config_dict["ncbi"]["SRA_file_column2"] != "" and pd.isnull(row[config_dict["ncbi"]["SRA_file_column2"]]) == False:
-                    print("WHY AM I HERE?")
-                    print("config_dict[\"ncbi\"][\"SRA_file_column2\"]: ", config_dict["ncbi"]["SRA_file_column2"])
-                    print("row[config_dict[\"ncbi\"][\"SRA_file_column2\"]]: ", row[config_dict["ncbi"]["SRA_file_column2"]])
-                    print("pd.isnull(row[config_dict[\"ncbi\"][\"SRA_file_column2\"]])", pd.isnull(row[config_dict["ncbi"]["SRA_file_column2"]]))
-                    sys.exit(1)
-                    file = ET.SubElement(addfile, "File")
-                    file.set("cloud_url", row[config_dict["ncbi"]["SRA_file_column2"]])
-                    datatype=ET.SubElement(file, "DataType")
-                    datatype.text = "generic-data"
+                # NOTE: we currently only support interleaved FASTQ files
+                # This code path path getting executed even when row[config_dict["ncbi"]["SRA_file_column2"]
+                # was an empty string
+                # if config_dict["ncbi"]["SRA_file_column2"] != "" and pd.isnull(row[config_dict["ncbi"]["SRA_file_column2"]]) == False:
+                #     file = ET.SubElement(addfile, "File")
+                #     file.set("cloud_url", row[config_dict["ncbi"]["SRA_file_column2"]])
+                #     datatype=ET.SubElement(file, "DataType")
+                #     datatype.text = "generic-data"
             elif config_dict["ncbi"]["SRA_file_location"].lower() == "local":
                 file = ET.SubElement(addfile, "File")
                 file.set("file_path", os.path.basename(row[config_dict["ncbi"]["SRA_file_column1"]]))

--- a/submission_preparation.py
+++ b/submission_preparation.py
@@ -120,6 +120,7 @@ def generate_XML(unique_name, main_df, generate_biosample, generate_sra):
                     print("WHY AM I HERE?")
                     print("config_dict[\"ncbi\"][\"SRA_file_column2\"]: ", config_dict["ncbi"]["SRA_file_column2"])
                     print("row[config_dict[\"ncbi\"][\"SRA_file_column2\"]]: ", row[config_dict["ncbi"]["SRA_file_column2"]])
+                    print("pd.isnull(row[config_dict[\"ncbi\"][\"SRA_file_column2\"]])", pd.isnull(row[config_dict["ncbi"]["SRA_file_column2"]]))
                     sys.exit(1)
                     file = ET.SubElement(addfile, "File")
                     file.set("cloud_url", row[config_dict["ncbi"]["SRA_file_column2"]])

--- a/submission_preparation.py
+++ b/submission_preparation.py
@@ -117,6 +117,8 @@ def generate_XML(unique_name, main_df, generate_biosample, generate_sra):
                 datatype=ET.SubElement(file, "DataType")
                 datatype.text = "generic-data"
                 if config_dict["ncbi"]["SRA_file_column2"] != "" and pd.isnull(row[config_dict["ncbi"]["SRA_file_column2"]]) == False:
+                    print("WHY AM I HERE?")
+                    sys.exit(1)
                     file = ET.SubElement(addfile, "File")
                     file.set("cloud_url", row[config_dict["ncbi"]["SRA_file_column2"]])
                     datatype=ET.SubElement(file, "DataType")


### PR DESCRIPTION
## DATA-1393
Gets rid of code path for FASTQ2 bc concentric uses interleaved FASTQs and the XML File tags for FASTQ2 were still getting included in the submission XML in spite of the file location (for FASTQ2) being empty in the input. 