### PR TITLE
DATA-1785: do not allow the seqsender CLI to overwrite the passed in metadata

### DIFF
--- a/submission_preparation.py
+++ b/submission_preparation.py
@@ -265,8 +265,6 @@ def gisaid_write(unique_name, main_df):
         else:
             author_list = author_list + "," + name["first"] + " " + name["last"]
     gisaid_df["covv_authors"] = author_list
-    if config_dict["general"]["baseline_surveillance"] == True:
-        gisaid_df["covv_sampling_strategy"] = "Baseline surveillance"
     for col in all_columns:
         if col not in gisaid_df:
             gisaid_df[col] = ""


### PR DESCRIPTION
## Summary
Removes the overwriting of the `covv_sampling_strategy` field in GISAID submission pipeline