### PR TITLE
BSCI-2343: catch ftp error

### DIFF
--- a/biosample_sra_submission.py
+++ b/biosample_sra_submission.py
@@ -66,4 +66,4 @@ def submit_ftp(unique_name, ncbi_sub_type, config, test, overwrite):
                 print('submit.ready upload failed.')
     except ftplib.all_errors as e:
         print('FTP error:', e)
-        sys.exit()
+        raise

--- a/seqsender.py
+++ b/seqsender.py
@@ -526,7 +526,19 @@ def submit_biosample_sra(unique_name, config, upload_log_path, test, ncbi_sub_ty
         test_type = False
     else:
         test_type = True
-    biosample_sra_submission.submit_ftp(unique_name=unique_name, ncbi_sub_type=ncbi_sub_type, config=config, test=test_type, overwrite=overwrite)
+
+    try:
+        biosample_sra_submission.submit_ftp(
+            unique_name=unique_name,
+            ncbi_sub_type=ncbi_sub_type,
+            config=config,
+            test=test_type,
+            overwrite=overwrite
+        )
+    except Exception as e:
+        print("submit_ftp error: " + str(e))
+        return
+
     curr_time = datetime.now()
     if ncbi_sub_type == "biosample_sra":
         update_csv(


### PR DESCRIPTION
## Summary
- Re-raises NCBI FTP submission exception, and removes sys.exit
- Catches FTP exception up the call stack to prevent subsequent submissions from being impacted